### PR TITLE
Fix playUpgradeCompleteSound hook address and arguments

### DIFF
--- a/GPTP/hooks/orders/research_upgrade_orders.cpp
+++ b/GPTP/hooks/orders/research_upgrade_orders.cpp
@@ -8,8 +8,8 @@ namespace {
 	bool isUnitUpgradeAvailable(CUnit* unit);															//033D0
 	void ApplySpeedUpgradeFromUpgradeType(CUnit* unit, u8 upgradeType);									//54540
 	void removeOrderFromUnitQueue(CUnit* unit, COrder* order);											//742D0
-	void playUpgradeCompleteSound();																	//8F070
-	void playResearchCompleteSound();																	//8F150
+	void playUpgradeCompleteSound(CUnit* unit);															//48F070
+	void playResearchCompleteSound(CUnit* unit);														//48F150
 	void setUpgradeLevel(u32 playerId, u32 upgradeType, u8 upgradeLevel);								//CE770
 	
 } //unnamed namespace
@@ -48,7 +48,7 @@ namespace hooks {
 
 				u8 upgradeLevel;
 				
-				playUpgradeCompleteSound();
+				playUpgradeCompleteSound(unit);
 
 				if(unit->building.upgradeType >= UpgradeId::UnusedUpgrade46)
 					upgradeLevel = UpgradesBw->currentLevel[unit->playerId][unit->building.upgradeType - UpgradeId::UnusedUpgrade46];
@@ -185,7 +185,7 @@ namespace hooks {
 			//54923
 			if(!bStopThere) {
 
-				playResearchCompleteSound();
+				playResearchCompleteSound(unit);
 
 				if(unit->building.techType < TechId::Restoration)
 					TechSc->isResearched[unit->playerId][unit->building.techType] = 1;
@@ -342,10 +342,11 @@ namespace {
 	;
 
 	const u32 Func_playUpgradeCompleteSound = 0x0048F070;
-	void playUpgradeCompleteSound() {
+	void playUpgradeCompleteSound(CUnit* unit) {
 
 		__asm {
 			PUSHAD
+			MOV ESI, unit
 			CALL Func_playUpgradeCompleteSound
 			POPAD
 		}
@@ -355,10 +356,11 @@ namespace {
 	;
 
 	const u32 Func_playResearchCompleteSound = 0x0048F150;
-	void playResearchCompleteSound() {
+	void playResearchCompleteSound(CUnit* unit) {
 
 		__asm {
 			PUSHAD
+			MOV ESI, unit
 			CALL Func_playResearchCompleteSound
 			POPAD
 		}


### PR DESCRIPTION
Hi @BoomerangAide!
This pull request fixes an issue where upgrading would cause a crash because of the pointer being incorrect. I've changed the pointer and added a CUnit* argument that ensures the right sound plays.

(Edit: Made a typo so had to force-push but it should merge cleanly regardless)